### PR TITLE
added support for stereo audio files.

### DIFF
--- a/baseline/src/bin/feature_extract.py
+++ b/baseline/src/bin/feature_extract.py
@@ -307,7 +307,10 @@ def main():
             fs, x = read_wav(wav_name, cutoff=args.highpass_cutoff)
             n_sample += x.shape[0]
             logging.info(wav_name+" "+str(x.shape[0])+" "+str(n_sample)+" "+str(count))
-
+            if len(x.shape) == 2:  # add support for stereo
+                x = x.mean(-1)
+            assert len(x.shape) == 1, f'shape {x.shape} is invalid'
+            
             # check sampling frequency
             if not fs == args.fs:
                 logging.info("ERROR: sampling frequency is not matched.")


### PR DESCRIPTION
This fixes the error `File "pyworld/pyworld.pyx", line 154, in pyworld.pyworld.harvest ValueError: ndarray is not C-contiguous`